### PR TITLE
help

### DIFF
--- a/src/SkyBlock/generator/generators/BasicIsland.php
+++ b/src/SkyBlock/generator/generators/BasicIsland.php
@@ -82,7 +82,7 @@ class BasicIsland extends SkyBlockGenerator {
     public function populateChunk($chunkX, $chunkZ) {
         for ($x = 0; $x < 16; $x++) {
             for ($z = 0; $z < 16; $z++) {
-                $this->level->getChunk($chunkX, $chunkZ)->setBiomeColor($x, $z, 133, 188, 86);
+                
             }
         }
     }

--- a/src/SkyBlock/skyblock/SkyBlockManager.php
+++ b/src/SkyBlock/skyblock/SkyBlockManager.php
@@ -15,6 +15,7 @@ use pocketmine\tile\Chest;
 use pocketmine\tile\Tile;
 use pocketmine\utils\Config;
 use SkyBlock\Main;
+use pocketmine\level\Level;
 
 class SkyBlockManager {
 

--- a/src/SkyBlock/skyblock/SkyBlockManager.php
+++ b/src/SkyBlock/skyblock/SkyBlockManager.php
@@ -44,7 +44,7 @@ class SkyBlockManager {
         $level->setBlock(new Vector3(10, 6, 4), new Block(0, 0));
         $level->loadChunk(10, 4, true);
         /** @var Chest $chest */
-        $chest = Tile::createTile("Chest",$level->getChunk(10 >> 4, 4 >> 4), new CompoundTag(" ", [
+        $chest = Tile::createTile("Chest",$level->getlevel(10 >> 4, 4 >> 4), new CompoundTag(" ", [
             new ListTag("Items", []),
             new StringTag("id", Tile::CHEST),
             new IntTag("x", 10),


### PR DESCRIPTION
hey fix sky block :(
chest can't create tile 

Unhandled exception executing command 'sb create' in skyblock: Call to undefined method pocketmine\level\Level::getlevel()

 Error: "Call to undefined method pocketmine\level\Level::getlevel()" (EXCEPTION) in "/plugins/SkyBlock/src/SkyBlock/skyblock/SkyBlockManager" at line 48
how to fix

fix please thank you